### PR TITLE
Add support for SparkFun MicroMod STM32 

### DIFF
--- a/src/boardsupport.h
+++ b/src/boardsupport.h
@@ -47,6 +47,12 @@
 #define DEFAULT_ETH_SPI_CS_Pin 21
 #endif
 
+#if defined(ARDUINO_MICROMOD_F405_DFU)
+#define DEFAULT_ETH_INT_Pin PC0
+#define DEFAULT_ETH_RESET_Pin PA0
+#define DEFAULT_ETH_SPI_CS_Pin PC4
+#endif
+
 #if !defined(DEFAULT_ETH_INT_Pin)
   #pragma message("No DEFAULT_ETH_INT_Pin defined, please set in being function")
   #define DEFAULT_ETH_INT_Pin 0

--- a/src/boardsupport_ard.cpp
+++ b/src/boardsupport_ard.cpp
@@ -67,21 +67,21 @@ void BSP_getConfigPins(uint16_t *value) { /* This board has no config pins, so o
 
 void BSP_disableInterrupts(void)
 {
-    #if defined(ARDUINO_ARCH_APOLLO3) || defined(ARDUINO_SPARKFUN_THINGPLUS_RP2040) || defined(ARDUINO_SPARKFUN_MICROMOD_RP2040)
+    #if defined(ARDUINO_ARCH_APOLLO3) || defined(ARDUINO_SPARKFUN_THINGPLUS_RP2040) || defined(ARDUINO_SPARKFUN_MICROMOD_RP2040) || defined(ARDUINO_MICROMOD_F405_DFU)
         //These architectures have problems with entering/exiting critical section so just don't do it
     #else
         noInterrupts();
-    #endif //defined(ARDUINO_ARCH_APOLLO3) || defined(ARDUINO_SPARKFUN_THINGPLUS_RP2040) || defined(ARDUINO_SPARKFUN_MICROMOD_RP2040)
+    #endif //defined(ARDUINO_ARCH_APOLLO3) || defined(ARDUINO_SPARKFUN_THINGPLUS_RP2040) || defined(ARDUINO_SPARKFUN_MICROMOD_RP2040) || defined(ARDUINO_MICROMOD_F405_DFU)
 }
 
 
 void BSP_enableInterrupts(void)
 {
-    #if defined(ARDUINO_ARCH_APOLLO3) || defined(ARDUINO_SPARKFUN_THINGPLUS_RP2040) || defined(ARDUINO_SPARKFUN_MICROMOD_RP2040)
+    #if defined(ARDUINO_ARCH_APOLLO3) || defined(ARDUINO_SPARKFUN_THINGPLUS_RP2040) || defined(ARDUINO_SPARKFUN_MICROMOD_RP2040) || defined(ARDUINO_MICROMOD_F405_DFU)
         //These architectures have problems with entering/exiting critical section so just don't do it
     #else
         noInterrupts();
-    #endif //defined(ARDUINO_ARCH_APOLLO3) || defined(ARDUINO_SPARKFUN_THINGPLUS_RP2040) || defined(ARDUINO_SPARKFUN_MICROMOD_RP2040)
+    #endif //defined(ARDUINO_ARCH_APOLLO3) || defined(ARDUINO_SPARKFUN_THINGPLUS_RP2040) || defined(ARDUINO_SPARKFUN_MICROMOD_RP2040) || defined(ARDUINO_MICROMOD_F405_DFU)
 }
 
 /*

--- a/src/boardsupport_ard.cpp
+++ b/src/boardsupport_ard.cpp
@@ -80,7 +80,7 @@ void BSP_enableInterrupts(void)
     #if defined(ARDUINO_ARCH_APOLLO3) || defined(ARDUINO_SPARKFUN_THINGPLUS_RP2040) || defined(ARDUINO_SPARKFUN_MICROMOD_RP2040) || defined(ARDUINO_MICROMOD_F405_DFU)
         //These architectures have problems with entering/exiting critical section so just don't do it
     #else
-        noInterrupts();
+        interrupts();
     #endif //defined(ARDUINO_ARCH_APOLLO3) || defined(ARDUINO_SPARKFUN_THINGPLUS_RP2040) || defined(ARDUINO_SPARKFUN_MICROMOD_RP2040) || defined(ARDUINO_MICROMOD_F405_DFU)
 }
 


### PR DESCRIPTION
Add support for SparkFun MicroMod STM32 

Tested with [DEV-17713](https://www.sparkfun.com/products/17713)

Fix BSP enableInterrupts to really enable interrupts