### PR TITLE
Correct minimum transmit length bug

### DIFF
--- a/src/SparkFun_SinglePairEthernet.cpp
+++ b/src/SparkFun_SinglePairEthernet.cpp
@@ -196,7 +196,7 @@ bool SinglePairEthernet::sendData(uint8_t *data, int dataLen, uint8_t * destMac)
     memcpy(&txBuf[txBufIdx][transmitLength], data, dataLen);
     transmitLength += dataLen;
     //Pad with 0's to mininmum transmit length
-    while(transmitLength < SPE_MIN_PAYLOAD_SIZE) txBuf[txBufIdx][transmitLength++] = 0;
+    while(transmitLength < SPE_FRAME_HEADER_SIZE + SPE_MIN_PAYLOAD_SIZE) txBuf[txBufIdx][transmitLength++] = 0;
 
     txBufDesc[txBufIdx].pBuf = &txBuf[txBufIdx][0];
     txBufDesc[txBufIdx].trxSize = transmitLength;


### PR DESCRIPTION
The sendData() method fails to send a frame if the payload is less than 46 bytes. This is because the sendData() method is supposed to pad the transmit buffer to the minimum size of a frame. 

The comparison that is used to accomplish this incorrectly checked only the size of the frame's payload. Changed the comparison to check the current size of the frame against the minimum frame size (which is the size of a frame header and the minimum payload size).